### PR TITLE
Implement admin-only user management

### DIFF
--- a/migrations/versions/58939bdbf1d7_add_role_field.py
+++ b/migrations/versions/58939bdbf1d7_add_role_field.py
@@ -1,0 +1,27 @@
+"""Add role field
+
+Revision ID: 58939bdbf1d7
+Revises: b50263b37f36
+Create Date: 2025-07-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '58939bdbf1d7'
+down_revision = 'b50263b37f36'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('role', sa.String(length=10), nullable=False, server_default='user'))
+    op.execute("UPDATE user SET role='user' WHERE role IS NULL")
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column('role', server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('role')

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,17 +3,17 @@
 <table border="1">
   <tr>
     <th>Email</th>
-    <th>Is Admin?</th>
+    <th>Role</th>
     <th>Merges</th>
     <th>Actions</th>
   </tr>
   {% for user in users %}
   <tr>
     <td>{{ user.email }}</td>
-    <td>{{ 'Yes' if user.is_admin else 'No' }}</td>
+    <td>{{ user.role }}</td>
     <td>{{ user.merge_count }}</td>
     <td>
-      <form method="POST" action="/delete-user/{{ user.id }}" style="display:inline;">
+      <form method="POST" action="/admin/delete_user/{{ user.id }}" style="display:inline;">
         <button onclick="return confirm('Delete this user?')">Delete</button>
       </form>
     </td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,6 +166,9 @@
         <form action="/logout" method="GET">
           <button type="submit">Logout</button>
         </form>
+        <form action="/delete_account" method="POST" style="margin-top:10px;">
+          <button onclick="return confirm('Delete your account?');" type="submit">Delete My Account</button>
+        </form>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add `role` field to the `User` model
- restrict admin routes using a new `@admin_required` decorator
- add admin API to list and delete users
- allow any user to delete their account
- add account delete button to the dashboard and admin table
- include alembic migration for new column

## Testing
- `python -m py_compile coremerge.py manage.py migrations/*.py migrations/versions/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68409a6b74e08320b20a151a758afc92